### PR TITLE
Add GraalVM support

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -69,3 +69,7 @@ tasks.bootBuildImage {
     builder.set("paketobuildpacks/builder-jammy-base:latest")
     environment.put("BP_NATIVE_IMAGE", "true")
 }
+
+graalvmNative {
+    toolchainDetection.set(false)
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,6 +14,9 @@ version = "0.0.1-SNAPSHOT"
 
 java {
     sourceCompatibility = JavaVersion.VERSION_17
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(21))
+    }
 }
 
 repositories {
@@ -72,4 +75,9 @@ tasks.bootBuildImage {
 
 graalvmNative {
     toolchainDetection.set(false)
+    binaries.all {
+        javaLauncher.set(javaToolchains.launcherFor {
+            languageVersion.set(JavaLanguageVersion.of(21))
+        })
+    }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     id("org.springframework.boot") version "3.1.8"
     id("io.spring.dependency-management") version "1.1.4"
     id("com.github.johnrengelman.shadow") version "7.1.2"
+    id("org.graalvm.buildtools.native") version "0.9.28"
     kotlin("jvm") version "1.8.22"
     kotlin("plugin.spring") version "1.8.22"
 }
@@ -66,4 +67,5 @@ tasks.withType<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar> {
 
 tasks.bootBuildImage {
     builder.set("paketobuildpacks/builder-jammy-base:latest")
+    environment.put("BP_NATIVE_IMAGE", "true")
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.java.installations.auto-download=true


### PR DESCRIPTION
## Summary
- add GraalVM native build plugin
- enable native image when building container image

## Testing
- `./gradlew tasks --all`
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_684530b3f784832da10347b09a902aab